### PR TITLE
Fix highlight may not be restored

### DIFF
--- a/autoload/fall/internal/msgarea.vim
+++ b/autoload/fall/internal/msgarea.vim
@@ -49,7 +49,7 @@ else
     if !exists('s:hl_msgarea')
       return
     endif
-    call hlset(s:hl_msgarea)
+    call hlset([extend(#{ force: 1 }, s:hl_msgarea[0])])
     unlet s:hl_msgarea
   endfunction
 endif


### PR DESCRIPTION
When MsgArea highlight is defined with :highlight-link, MsgArea highlight is not restored properly.

### Reproduce steps

- Prepare a terminal with true color support.
- Prepare this `vimrc.vim`.

```vim
set nocompatible
set runtimepath^=~/.cache/vim/pack/minpac/opt/denops.vim/
set runtimepath^=~/.cache/vim/pack/minpac/opt/vim-fall/
set termguicolors
colorscheme habamax
highlight! link MsgArea ErrorMsg
```

- Launch Vim (not Neovim) with `vim -u /path/to/vimrc.vim`
- Check MsgArea highlight.
- Run command `:Fall line`.
- Type `<ESC>` to exit fall.vim
- Check MsgArea highlight.  It's different from before.

### Environment

- macOS 14
- wezterm 20240203-110809-5046fc22
- Vim 9.1.0658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced highlight settings management for improved control over highlighting behavior.

- **Bug Fixes**
	- Improved functionality of highlight application to ensure consistent visual representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->